### PR TITLE
Possible resolution for the following errors when building:

### DIFF
--- a/attributes.c
+++ b/attributes.c
@@ -36,7 +36,7 @@ static ssize_t set_reset
 
   return count;                                        
 } 
-static DEVICE_ATTR(reset, S_IWUGO | S_IRUGO, show_attr, set_reset );
+static DEVICE_ATTR(reset, 0660, show_attr, set_reset );
 
 /* helper macro to make individual set-routines for attributes */
 #define ibuddy_toggle_attr( name, startval, bitpos )	\
@@ -49,7 +49,7 @@ static ssize_t set_##name \
         toggle( buddy, startval, bitpos );		     \
         return count;                                        \
 } \
-static DEVICE_ATTR(name, S_IWUGO | S_IRUGO, show_attr, set_##name );
+static DEVICE_ATTR(name, 0660, show_attr, set_##name );
 
 /* control attributes for the i-buddy. 
    1 is one bit value,  3 is for 2 bits

--- a/main.c
+++ b/main.c
@@ -179,12 +179,12 @@ static struct usb_driver ibuddy_driver = {
 /* -------------------------------------------------------------------- */
 /* module parameters */
 static unsigned int timeout = 0;
-module_param( timeout, uint, S_IRUGO );
+module_param( timeout, uint, 0660 );
 MODULE_PARM_DESC( timeout, 
 		  "timeout for usb_control_msg(). default 0 (no timeout)" );
 #if DEBUG_IBUDDY == 1
 bool ibuddy_debug = 0;
-module_param_named( debug, ibuddy_debug, bool, S_IRUGO );
+module_param_named( debug, ibuddy_debug, bool, 0660 );
 MODULE_PARM_DESC( debug, "are debug messages enabled" );
 #endif
 


### PR DESCRIPTION
      include/linux/bug.h:33:45: error: negative width in bit-field ‘<anonymous>’
     #define BUILD_BUG_ON_ZERO(e) (sizeof(struct { int:-!!(e); }))
                                                 ^
    include/linux/kernel.h:833:3: note: in expansion of macro ‘BUILD_BUG_ON_ZERO’
       BUILD_BUG_ON_ZERO((perms) & 2) +     \
       ^
    include/linux/sysfs.h:102:12: note: in expansion of macro ‘VERIFY_OCTAL_PERMISSIONS’
        .mode = VERIFY_OCTAL_PERMISSIONS(_mode) },  \

    ...